### PR TITLE
Increase --manage-timeout-seconds

### DIFF
--- a/build/go/protos/opts/ps_opts_manage.pb.go
+++ b/build/go/protos/opts/ps_opts_manage.pb.go
@@ -110,8 +110,8 @@ type GlobalManageOptions struct {
 	ManageAddress string `protobuf:"bytes,1,opt,name=manage_address,json=manageAddress,proto3" json:"manage_address,omitempty" kong:"help='Plumber server gRPC API address',default='localhost:9090'"`
 	// @gotags: kong:"help='Plumber server auth token',default='batchcorp'"
 	ManageToken string `protobuf:"bytes,2,opt,name=manage_token,json=manageToken,proto3" json:"manage_token,omitempty" kong:"help='Plumber server auth token',default='batchcorp'"`
-	// @gotags: kong:"help='gRPC call timeout seconds',default=5"
-	ManageTimeoutSeconds int64 `protobuf:"varint,3,opt,name=manage_timeout_seconds,json=manageTimeoutSeconds,proto3" json:"manage_timeout_seconds,omitempty" kong:"help='gRPC call timeout seconds',default=5"`
+	// @gotags: kong:"help='gRPC call timeout seconds',default=10"
+	ManageTimeoutSeconds int64 `protobuf:"varint,3,opt,name=manage_timeout_seconds,json=manageTimeoutSeconds,proto3" json:"manage_timeout_seconds,omitempty" kong:"help='gRPC call timeout seconds',default=10"`
 	// @gotags: kong:"help='Use TLS when talking to plumber server',default='false'"
 	ManageUseTls bool `protobuf:"varint,4,opt,name=manage_use_tls,json=manageUseTls,proto3" json:"manage_use_tls,omitempty" kong:"help='Use TLS when talking to plumber server',default='false'"`
 	// @gotags: kong:"help='Skip TLS server certificate verification',default='false'"

--- a/protos/opts/ps_opts_manage.proto
+++ b/protos/opts/ps_opts_manage.proto
@@ -41,7 +41,7 @@ message GlobalManageOptions {
   // @gotags: kong:"help='Plumber server auth token',default='batchcorp'"
   string manage_token = 2;
 
-  // @gotags: kong:"help='gRPC call timeout seconds',default=5"
+  // @gotags: kong:"help='gRPC call timeout seconds',default=10"
   int64 manage_timeout_seconds = 3;
 
   // @gotags: kong:"help='Use TLS when talking to plumber server',default='false'"


### PR DESCRIPTION
Since the tunnel start has a 5 second delay `if err := d.StartTunnel(5 * time.Second);`, the timeout needs to be greater than that, to avoid a context timeout on every create tunnel request